### PR TITLE
v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,8 @@ jobs:
           cat > pages/index.md <<EOL
           Test
           EOL
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: pre-installed
-          extensions: mbstring, fileinfo, gd, imagick, intl, gettext, :redis
       - name: Run Action
         uses: ./
         with:
-          version: '8.93.1'
+          version: '8.94.3'
           options: '-vv'
-          install_themes: 'yes'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,12 @@ name: test
 
 on:
   push:
-    branches: [master]
+    branches: [main, master]
   workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -23,3 +27,16 @@ jobs:
         with:
           version: '8.94.3'
           options: '-vv'
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,5 @@ jobs:
         uses: ./
         with:
           version: '8.93.1'
-          config: 'config.yml'
-          args: '-vv'
+          options: '-vv'
           install_themes: 'yes'

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This GitHub Action build a [_Cecil_](https://cecil.app) site and upload a GitHub
   uses: Cecilapp/Cecil-Action@v4
   # optional
   with:
-    version: 8.0.0       # default: latest version
-    options: -v --config=config.yml # default: "-v" (verbose)
-    install_themes: yes  # default: "yes"
+    version: 8.0.0                   # default: latest version
+    options: -v --config=config.yml  # default: "-v" (verbose)
+    install_themes: yes              # default: "yes"
 ```
 
 ### Workflow example
@@ -35,16 +35,13 @@ on:
   push:
     branches: [main, master]
   workflow_dispatch:
-
 permissions:
   contents: read
   pages: write
   id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,7 +50,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Build site
         uses: Cecilapp/Cecil-Action@v4
-
   deploy:
     needs: build
     environment:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This GitHub Action builds a [_Cecil_](https://cecil.app) site and uploads a GitH
   # optional
   with:
     version: 8.0.0                   # default: latest version
-    options: -v --config=config.yml  # default: "-v" (verbose)
     install_themes: "yes"            # default: "yes"
+    options: -v --config=config.yml  # default: "-v" (verbose)
 ```
 
 ### Workflow example
@@ -25,9 +25,9 @@ The following workflow:
 3. setup PHP
 4. downloads Cecil
 5. installs theme(s)
-6. runs Cecil to build the site
-7. upload artifact
-8. deploys `_site` to GitHub Pages
+6. runs Cecil build
+7. upload pages artifact
+8. deploys to GitHub Pages
 
 ```yaml
 name: Build and deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This GitHub Action build a [_Cecil_](https://cecil.app) site and upload a GitHub
   # optional
   with:
     version: 8.0.0       # default: latest version
-    config: config.yml   # default: empty
-    options: -v          # default: "-v" (verbose)
+    options: -v --config=config.yml # default: "-v" (verbose)
     install_themes: yes  # default: "yes"
 ```
 
@@ -21,12 +20,12 @@ This GitHub Action build a [_Cecil_](https://cecil.app) site and upload a GitHub
 
 The following workflow:
 
-1. runs on pushes to the `master` branch
+1. runs on pushes to the `main` and `master` branches
 2. checkout source
 3. setup PHP
 4. downloads Cecil
 5. installs theme(s)
-6. runs `php cecil.phar build -v`
+6. runs Cecil to build the site
 7. upload artifact
 8. deploys `_site` to GitHub Pages
 
@@ -34,8 +33,8 @@ The following workflow:
 name: Build and deploy to GitHub Pages
 on:
   push:
-    branches: [main] # or [master]
-  workflow_dispatch: # run manually
+    branches: [main, master]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -52,24 +51,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: pre-installed
-          extensions: mbstring, fileinfo, gd, imagick, intl, gettext, :redis
-
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v6
-
       - name: Build site
         uses: Cecilapp/Cecil-Action@v4
-        with:
-          options: '-v --baseurl="${{ steps.pages.outputs.base_url }}/"'
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cecil build Action
 
-This GitHub Action build a [_Cecil_](https://cecil.app) site and upload a GitHub Pages artifact.
+This GitHub Action builds a [_Cecil_](https://cecil.app) site and uploads a GitHub Pages artifact.
 
 [![test](https://github.com/Cecilapp/Action/actions/workflows/test.yml/badge.svg)](https://github.com/Cecilapp/Action/actions/workflows/test.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cecil build Action
 
-This GitHub Action builds a static site with [_Cecil_](https://cecil.app).
+This GitHub Action build a [_Cecil_](https://cecil.app) site and upload a GitHub Pages artifact.
 
 [![test](https://github.com/Cecilapp/Action/actions/workflows/test.yml/badge.svg)](https://github.com/Cecilapp/Action/actions/workflows/test.yml)
 
@@ -8,13 +8,13 @@ This GitHub Action builds a static site with [_Cecil_](https://cecil.app).
 
 ```yaml
 - name: Build site
-  uses: Cecilapp/Cecil-Action@v3
+  uses: Cecilapp/Cecil-Action@v4
   # optional
   with:
-    version: '8.0.0'      # default: latest version
-    config: 'config.yml'  # default: ''
-    args: '-v'            # default: '-v'
-    install_themes: 'yes' # default: 'yes'
+    version: 8.0.0       # default: latest version
+    config: config.yml   # default: empty
+    options: -v          # default: "-v" (verbose)
+    install_themes: yes  # default: "yes"
 ```
 
 ### Workflow example
@@ -27,7 +27,8 @@ The following workflow:
 4. downloads Cecil
 5. installs theme(s)
 6. runs `php cecil.phar build -v`
-7. deploys `_site` to GitHub Pages
+7. upload artifact
+8. deploys `_site` to GitHub Pages
 
 ```yaml
 name: Build and deploy to GitHub Pages
@@ -60,15 +61,15 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build site
-        uses: Cecilapp/Cecil-Action@v3
+        uses: Cecilapp/Cecil-Action@v4
         with:
-          args: '-v --baseurl="${{ steps.pages.outputs.base_url }}/"'
+          options: '-v --baseurl="${{ steps.pages.outputs.base_url }}/"'
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     needs: build
@@ -79,7 +80,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This GitHub Action builds a [_Cecil_](https://cecil.app) site and uploads a GitH
   with:
     version: 8.0.0                   # default: latest version
     options: -v --config=config.yml  # default: "-v" (verbose)
-    install_themes: yes              # default: "yes"
+    install_themes: "yes"            # default: "yes"
 ```
 
 ### Workflow example

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   version:
     description: "Cecil version (optional, last version by default)."
   install_themes:
-    description: "Use `no` to do not install theme(s) (optional, `yes` by default)."
+    description: "Set to `no` to skip installing theme(s) (optional, `yes` by default)."
     default: yes
 branding:
   icon: package

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "Cecil version (optional, last version by default)."
   install_themes:
     description: "Set to `no` to skip installing theme(s) (optional, `yes` by default)."
-    default: yes
+    default: "yes"
 branding:
   icon: package
   color: white

--- a/action.yml
+++ b/action.yml
@@ -1,45 +1,76 @@
-name: 'Cecil Action'
-description: 'Build a Cecil static site.'
-author: 'Arnaud Ligny'
+name: "Cecil Action"
+description: "Build a Cecil static site."
+author: "Arnaud Ligny"
 inputs: 
   version:
-    description: 'Cecil version (optional, last version by default).'
+    description: "Cecil version (optional, last version by default)."
   config:
-    description: 'Cecil configuration file (optional, `cecil.yml` by default).'
-  args:
-    description: 'Cecil arguments (optionnal, `-v` by default).'
-    default: '-v'
+    description: "Cecil configuration file (optional, empty by default)."
+  options:
+    description: "Cecil options (optional, `-v` by default)."
+    default: -v
   install_themes:
-    description: 'Use "no" to do not install theme(s) (optionnal, `yes` by default).'
-    default: 'yes'
+    description: "Use `no` to do not install theme(s) (optional, `yes` by default)."
+    default: yes
 branding:
-  icon: 'package'
-  color: 'white'
+  icon: package
+  color: white
 runs:
-  using: 'composite'
+  using: composite
   steps:
-    - run: |
-        # Downloading Cecil
+    - name: Validate Cecil version
+      shell: bash
+      run: |
+        version="${{ inputs.version }}"
+        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
+          echo "Invalid Cecil version: '$version' (expected e.g. 8.76.3)" >&2
+          exit 1
+        fi
+    - name: Validate config file
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.config }}" && ! -f "${{ inputs.config }}" ]]; then
+          echo "Config file '${{ inputs.config }}' not found." >&2
+          exit 1
+        fi
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: pre-installed
+        extensions: mbstring, fileinfo, gd, imagick, intl, gettext, :redis
+    - name: Downloading Cecil
+      shell: bash
+      run: |
         if [[ -z "${{ inputs.version }}" ]]; then
-          echo "Downloading Cecil..."
+          echo "Downloading latest Cecil..."
           curl -sSOL https://cecil.app/cecil.phar
         else
           echo "Downloading Cecil ${{ inputs.version }}..."
           curl -sSOL https://cecil.app/download/${{ inputs.version }}/cecil.phar
         fi
-        # Installing theme(s)
+    - name: Installing theme(s)
+      shell: bash
+      run: |
         if [[ -f "composer.json" && ${{ inputs.install_themes }} = 'yes' ]]; then
           echo "Installing theme(s)..."
           composer install --prefer-dist --no-dev --no-progress --no-interaction --quiet
         fi
-        # Running build
+    - name: Setup Pages
+      id: pages
+      uses: actions/configure-pages@v6
+    - name: Building site with Cecil
+      shell: bash
+      run: |
         if [[ -z "${{ inputs.config }}" ]]; then
-          php cecil.phar build ${{ inputs.args }}
+          php cecil.phar build ${{ inputs.options }}
         else
-          php cecil.phar build ${{ inputs.args }} --config=${{ inputs.config }}
+          php cecil.phar build ${{ inputs.options }} --config=${{ inputs.config }} --baseurl="${{ steps.pages.outputs.base_url }}/"
         fi
         # Summary
         if [ $? == 0 ]; then
           echo "Site built with Cecil ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         fi
-      shell: bash
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v5
+      with:
+        path: ${{ inputs.working_directory }}/${{ inputs.output_dir }}

--- a/action.yml
+++ b/action.yml
@@ -2,14 +2,14 @@ name: "Cecil Action"
 description: "Build a Cecil static site."
 author: "Arnaud Ligny"
 inputs:
-  options:
-    description: "Cecil options (optional, `-v` by default)."
-    default: -v
   version:
     description: "Cecil version (optional, last version by default)."
   install_themes:
     description: "Set to `no` to skip installing theme(s) (optional, `yes` by default)."
     default: "yes"
+  options:
+    description: "Cecil options (optional, `-v` by default)."
+    default: -v
 branding:
   icon: package
   color: white

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,9 @@ runs:
       shell: bash
       run: |
         version="${{ inputs.version }}"
-        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
+        if [[ -z "$version" ]]; then
+          echo "No Cecil version provided; using latest release."
+        elif [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
           echo "Invalid Cecil version: '$version' (expected e.g. 8.76.3)" >&2
           exit 1
         fi

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,12 @@
 name: "Cecil Action"
 description: "Build a Cecil static site."
 author: "Arnaud Ligny"
-inputs: 
-  version:
-    description: "Cecil version (optional, last version by default)."
+inputs:
   options:
     description: "Cecil options (optional, `-v` by default)."
     default: -v
+  version:
+    description: "Cecil version (optional, last version by default)."
   install_themes:
     description: "Use `no` to do not install theme(s) (optional, `yes` by default)."
     default: yes
@@ -16,6 +16,11 @@ branding:
 runs:
   using: composite
   steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: pre-installed
+        extensions: mbstring, fileinfo, gd, imagick, intl, gettext, :redis
     - name: Validate Cecil version
       shell: bash
       run: |
@@ -24,11 +29,6 @@ runs:
           echo "Invalid Cecil version: '$version' (expected e.g. 8.76.3)" >&2
           exit 1
         fi
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: pre-installed
-        extensions: mbstring, fileinfo, gd, imagick, intl, gettext, :redis
     - name: Downloading Cecil
       shell: bash
       run: |
@@ -57,7 +57,23 @@ runs:
         if [ $? == 0 ]; then
           echo "Site built with Cecil ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
         fi
+    - name: Resolve output directory
+      id: output
+      shell: bash
+      run: |
+        options='${{ inputs.options }}'
+        output_dir="_site"
+        if [[ "$options" =~ (^|[[:space:]])--output=([^[:space:]]+) ]]; then
+          output_dir="${BASH_REMATCH[2]}"
+        elif [[ "$options" =~ (^|[[:space:]])--output[[:space:]]+([^[:space:]]+) ]]; then
+          output_dir="${BASH_REMATCH[2]}"
+        elif [[ "$options" =~ (^|[[:space:]])-o[[:space:]]+([^[:space:]]+) ]]; then
+          output_dir="${BASH_REMATCH[2]}"
+        elif [[ "$options" =~ (^|[[:space:]])-o([^[:space:]]+) ]]; then
+          output_dir="${BASH_REMATCH[2]}"
+        fi
+        echo "output_dir=$output_dir" >> "$GITHUB_OUTPUT"
     - name: Upload GitHub Pages artifact
       uses: actions/upload-pages-artifact@v5
       with:
-        path: ${{ inputs.working_directory }}/${{ inputs.output_dir }}
+        path: ./${{ steps.output.outputs.output_dir }}

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,6 @@ author: "Arnaud Ligny"
 inputs: 
   version:
     description: "Cecil version (optional, last version by default)."
-  config:
-    description: "Cecil configuration file (optional, empty by default)."
   options:
     description: "Cecil options (optional, `-v` by default)."
     default: -v
@@ -24,13 +22,6 @@ runs:
         version="${{ inputs.version }}"
         if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
           echo "Invalid Cecil version: '$version' (expected e.g. 8.76.3)" >&2
-          exit 1
-        fi
-    - name: Validate config file
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.config }}" && ! -f "${{ inputs.config }}" ]]; then
-          echo "Config file '${{ inputs.config }}' not found." >&2
           exit 1
         fi
     - name: Setup PHP
@@ -55,17 +46,13 @@ runs:
           echo "Installing theme(s)..."
           composer install --prefer-dist --no-dev --no-progress --no-interaction --quiet
         fi
-    - name: Setup Pages
+    - name: Setup GitHub Pages
       id: pages
       uses: actions/configure-pages@v6
     - name: Building site with Cecil
       shell: bash
       run: |
-        if [[ -z "${{ inputs.config }}" ]]; then
-          php cecil.phar build ${{ inputs.options }}
-        else
-          php cecil.phar build ${{ inputs.options }} --config=${{ inputs.config }} --baseurl="${{ steps.pages.outputs.base_url }}/"
-        fi
+        php cecil.phar build ${{ inputs.options }} --baseurl="${{ steps.pages.outputs.base_url }}/"
         # Summary
         if [ $? == 0 ]; then
           echo "Site built with Cecil ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Installing theme(s)
       shell: bash
       run: |
-        if [[ -f "composer.json" && ( "${{ inputs.install_themes }}" = 'yes' || "${{ inputs.install_themes }}" = 'true' ) ]]; then
+        if [[ -f "composer.json" && ( "${{ inputs.install_themes }}" = "yes" || "${{ inputs.install_themes }}" = "true" ) ]]; then
           echo "Installing theme(s)..."
           composer install --prefer-dist --no-dev --no-progress --no-interaction --quiet
         fi

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Installing theme(s)
       shell: bash
       run: |
-        if [[ -f "composer.json" && ${{ inputs.install_themes }} = 'yes' ]]; then
+        if [[ -f "composer.json" && ( "${{ inputs.install_themes }}" = 'yes' || "${{ inputs.install_themes }}" = 'true' ) ]]; then
           echo "Installing theme(s)..."
           composer install --prefer-dist --no-dev --no-progress --no-interaction --quiet
         fi


### PR DESCRIPTION
This pull request introduces significant updates to the Cecil GitHub Action, modernizing its configuration, improving flexibility, and streamlining the workflow for building and deploying Cecil sites to GitHub Pages. Key improvements include a new unified `options` input for Cecil CLI flags, enhanced artifact upload support, and updated documentation and workflow examples to match these changes.

**Action input and workflow improvements:**

* Replaced the separate `config` and `args` inputs with a single `options` input in `action.yml`, allowing users to specify all Cecil CLI options in one place [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R79) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L30-R30).
* Added a new step to resolve the output directory dynamically based on the `options` input, ensuring correct artifact upload regardless of custom output paths.
* Integrated artifact upload directly into the action using `actions/upload-pages-artifact@v5`, making it easier to deploy to GitHub Pages.

**Documentation and example updates:**

* Updated `README.md` to reflect the new `options` input, the artifact upload step, and the latest recommended usage patterns, including updated workflow examples and GitHub Action versions [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R52) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R62).
* Changed the deploy step in the example workflow to use `actions/deploy-pages@v5` for compatibility with the latest GitHub Pages deployment process.

**General enhancements and cleanup:**

* Improved input validation and error handling for the Cecil version input.
* Added a step for PHP setup and ensured all necessary PHP extensions are installed before building the site.
* Cleaned up formatting and descriptions in `action.yml` for better consistency and readability.